### PR TITLE
Specify version of okhttp3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,12 @@
       <artifactId>openshift-restclient-java</artifactId>
       <version>9.0.1.Final</version>
     </dependency>
+    <!-- I think quarkus is using older okhttp3, so we have to use latest one so that openshift-restclient-java is happy -->
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>4.1.1</version>
+    </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-scheduler</artifactId>


### PR DESCRIPTION
This is done to make openshift-restclient-java happy. For some reason
it's stuck in 3.14.4 (Quarkus' fault?) and that makes
openshift-restclient-java fail with:

```
2020-09-29 09:06:10,347 ERROR [io.qua.sch.run.SimpleScheduler] (executor-thread-1) Error occured while executing task for trigger IntervalTrigger [id=1_org.jboss.pnc.openshiftcleaner.cron.ScheduledCleanup_ScheduledInvoker_cleanup_876dc04f8610241fa6f344e3d6fa75a663b05f35, interval=43200000]: java.lang.NoSuchMethodError: okhttp3.RequestBody.create(Ljava/lang/String;Lokhttp3/MediaType;)Lokhttp3/RequestBody;
```